### PR TITLE
Add eigen dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -10,6 +10,9 @@
 
     <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
     <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>
+
+    <build_depend>eigen</build_depend>
+
     <test_depend condition="$ROS_VERSION == 2">ament_cmake_gtest</test_depend>
 
     <export>


### PR DESCRIPTION
The CMakeLists.txt looks for it, so if you just use `rosdep install && colcon build` this hadn't yet installed the proper dependencies.